### PR TITLE
Fix assertion error on TextFormField in code_editor_wrapper.dart

### DIFF
--- a/lib/src/impl/widgets/io_editor/code_editor_wrapper.dart
+++ b/lib/src/impl/widgets/io_editor/code_editor_wrapper.dart
@@ -15,7 +15,7 @@ class CodeEditorWrapper extends ConsumerWidget {
       required this.usesCodeControllers,
       this.textEditingController,
       this.onChanged,
-        this.minLines = 10,
+      this.minLines = 10,
       this.readOnly = false});
 
   @override
@@ -27,6 +27,12 @@ class CodeEditorWrapper extends ConsumerWidget {
         data:
             CodeThemeData(styles: textEditorThemes[settings.textEditorTheme]!),
         child: CodeField(
+          cursorColor: Theme.of(context).focusColor,
+          decoration: BoxDecoration(
+            color: Theme.of(context).backgroundColor,
+          ),
+          lineNumberStyle:
+              LineNumberStyle(textStyle: Theme.of(context).textTheme.bodySmall),
           wrap: settings.textEditorWrap,
           lineNumbers: settings.textEditorDisplayLineNumbers,
           textStyle: TextStyle(

--- a/lib/src/impl/widgets/io_editor/code_editor_wrapper.dart
+++ b/lib/src/impl/widgets/io_editor/code_editor_wrapper.dart
@@ -50,7 +50,7 @@ class CodeEditorWrapper extends ConsumerWidget {
       );
     } else {
       return TextFormField(
-        maxLines: settings.textEditorWrap ? null : 10,
+        maxLines: settings.textEditorWrap ? null : minLines,
         style: TextStyle(
             fontFamily: settings.textEditorFontFamily,
             fontSize: settings.textEditorFontSize,


### PR DESCRIPTION
When opening page with TextFormField set greater than 10 with Wrap Text set to false it will trigger assertion error because maxLines is smaller than minLines. For example go to Text Diff page with Wrap Text set to false in settings.